### PR TITLE
disable gcc built-in malloc

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,6 +16,7 @@ LOCAL_CFLAGS := \
 	-DDYNAMIC_LIB \
 	-fvisibility=hidden \
 	-DANDROID \
+	-fno-builtin-malloc \
 	$(libc_common_cflags)
 
 LOCAL_C_INCLUDES := $(libc_common_c_includes) bionic/libc


### PR DESCRIPTION
Hi,
   I have seen this is required so that efence works fine with latest versions of gcc.

cheers,
E.-
